### PR TITLE
fix(auth): rename user → me in 7 files to match AuthContext shape

### DIFF
--- a/.emergent/emergent.yml
+++ b/.emergent/emergent.yml
@@ -1,5 +1,5 @@
 {
   "env_image_name": "fastapi_react_mongo_shadcn_base_image_cloud_arm:release-17042026-1",
-  "job_id": "3269969a-9972-452b-8490-6a7c3d18a5b3",
-  "created_at": "2026-05-26T20:57:19.150139+00:00Z"
+  "job_id": "7354ebc9-5afe-4cb2-a71c-cf0d30fe9812",
+  "created_at": "2026-05-28T01:14:03.195218+00:00Z"
 }

--- a/.emergent/emergent.yml
+++ b/.emergent/emergent.yml
@@ -1,5 +1,5 @@
 {
   "env_image_name": "fastapi_react_mongo_shadcn_base_image_cloud_arm:release-17042026-1",
   "job_id": "7354ebc9-5afe-4cb2-a71c-cf0d30fe9812",
-  "created_at": "2026-05-28T01:14:03.195218+00:00Z"
+  "created_at": "2026-05-28T01:16:36.502352+00:00Z"
 }

--- a/backend/var/inbound/e2e-cap-awaiting-1779928824827/000__invoice-awaiting.pdf
+++ b/backend/var/inbound/e2e-cap-awaiting-1779928824827/000__invoice-awaiting.pdf
@@ -1,0 +1,3 @@
+%PDF-1.4
+stub for E2E capture seed
+%%EOF

--- a/backend/var/inbound/e2e-cap-awaiting-1779930559822/000__invoice-awaiting.pdf
+++ b/backend/var/inbound/e2e-cap-awaiting-1779930559822/000__invoice-awaiting.pdf
@@ -1,0 +1,3 @@
+%PDF-1.4
+stub for E2E capture seed
+%%EOF

--- a/backend/var/inbound/e2e-cap-awaiting-1779930631421/000__invoice-awaiting.pdf
+++ b/backend/var/inbound/e2e-cap-awaiting-1779930631421/000__invoice-awaiting.pdf
@@ -1,0 +1,3 @@
+%PDF-1.4
+stub for E2E capture seed
+%%EOF

--- a/backend/var/inbound/e2e-cap-failed-1779928824867/000__invoice-failed.pdf
+++ b/backend/var/inbound/e2e-cap-failed-1779928824867/000__invoice-failed.pdf
@@ -1,0 +1,3 @@
+%PDF-1.4
+stub for E2E capture seed
+%%EOF

--- a/backend/var/inbound/e2e-cap-failed-1779930559845/000__invoice-failed.pdf
+++ b/backend/var/inbound/e2e-cap-failed-1779930559845/000__invoice-failed.pdf
@@ -1,0 +1,3 @@
+%PDF-1.4
+stub for E2E capture seed
+%%EOF

--- a/backend/var/inbound/e2e-cap-failed-1779930631439/000__invoice-failed.pdf
+++ b/backend/var/inbound/e2e-cap-failed-1779930631439/000__invoice-failed.pdf
@@ -1,0 +1,3 @@
+%PDF-1.4
+stub for E2E capture seed
+%%EOF

--- a/backend/var/inbound/e2e-cap-queued-1779928824891/000__invoice-queued.pdf
+++ b/backend/var/inbound/e2e-cap-queued-1779928824891/000__invoice-queued.pdf
@@ -1,0 +1,3 @@
+%PDF-1.4
+stub for E2E capture seed
+%%EOF

--- a/backend/var/inbound/e2e-cap-queued-1779930559853/000__invoice-queued.pdf
+++ b/backend/var/inbound/e2e-cap-queued-1779930559853/000__invoice-queued.pdf
@@ -1,0 +1,3 @@
+%PDF-1.4
+stub for E2E capture seed
+%%EOF

--- a/backend/var/inbound/e2e-cap-queued-1779930631446/000__invoice-queued.pdf
+++ b/backend/var/inbound/e2e-cap-queued-1779930631446/000__invoice-queued.pdf
@@ -1,0 +1,3 @@
+%PDF-1.4
+stub for E2E capture seed
+%%EOF

--- a/frontend/src/components/po/POApprovalsTab.jsx
+++ b/frontend/src/components/po/POApprovalsTab.jsx
@@ -39,9 +39,9 @@ import { fmtGBP } from '@/lib/poFormat';
 
 export default function POApprovalsTab() {
   const { id: projectId } = useParams();
-  const { user } = useAuth();
-  const canSensitive = canViewSensitivePO(user);
-  const canApprove   = canApprovePO(user);
+  const { me } = useAuth();
+  const canSensitive = canViewSensitivePO(me);
+  const canApprove   = canApprovePO(me);
 
   // Pass the status filter through. Backend already honours
   // `status_in` via the `/purchase-orders?project_id=X&status=...`
@@ -51,7 +51,7 @@ export default function POApprovalsTab() {
     params: { status: 'pending_approval' },
   });
 
-  if (!canViewPOs(user)) {
+  if (!canViewPOs(me)) {
     return (
       <div className="text-sm" data-testid="po-approvals-forbidden">
         You do not have permission to view purchase orders.

--- a/frontend/src/components/po/__tests__/POApprovalsTab.test.jsx
+++ b/frontend/src/components/po/__tests__/POApprovalsTab.test.jsx
@@ -41,14 +41,14 @@ describe('<POApprovalsTab/> — R7.5 per-project approvals dashboard', () => {
   beforeEach(() => { jest.clearAllMocks(); });
 
   test('forbidden persona sees the perm-gated copy', () => {
-    useAuth.mockReturnValue({ user: ME_NO_VIEW });
+    useAuth.mockReturnValue({ me: ME_NO_VIEW });
     useProjectPOs.mockReturnValue({ data: { items: [] }, isLoading: false });
     renderWithProviders(<POApprovalsTab />);
     expect(screen.getByTestId('po-approvals-forbidden')).toBeInTheDocument();
   });
 
   test('renders only pending_approval rows (client-side filter fallback)', () => {
-    useAuth.mockReturnValue({ user: ME_APPROVER });
+    useAuth.mockReturnValue({ me: ME_APPROVER });
     useProjectPOs.mockReturnValue({
       data: {
         items: [
@@ -69,14 +69,14 @@ describe('<POApprovalsTab/> — R7.5 per-project approvals dashboard', () => {
   });
 
   test('empty list renders the "no POs awaiting approval" state', () => {
-    useAuth.mockReturnValue({ user: ME_APPROVER });
+    useAuth.mockReturnValue({ me: ME_APPROVER });
     useProjectPOs.mockReturnValue({ data: { items: [] }, isLoading: false });
     renderWithProviders(<POApprovalsTab />);
     expect(screen.getByTestId('po-approvals-empty')).toBeInTheDocument();
   });
 
   test('approver persona — Review affordance on each row', () => {
-    useAuth.mockReturnValue({ user: ME_APPROVER });
+    useAuth.mockReturnValue({ me: ME_APPROVER });
     useProjectPOs.mockReturnValue({
       data: { items: [makeRow({ id: 'a' })] },
       isLoading: false,
@@ -87,7 +87,7 @@ describe('<POApprovalsTab/> — R7.5 per-project approvals dashboard', () => {
   });
 
   test('read-only persona — sees list but no Review affordance', () => {
-    useAuth.mockReturnValue({ user: ME_READONLY });
+    useAuth.mockReturnValue({ me: ME_READONLY });
     useProjectPOs.mockReturnValue({
       data: { items: [makeRow({ id: 'a' })] },
       isLoading: false,
@@ -99,14 +99,14 @@ describe('<POApprovalsTab/> — R7.5 per-project approvals dashboard', () => {
   });
 
   test('loading state renders po-approvals-loading', () => {
-    useAuth.mockReturnValue({ user: ME_APPROVER });
+    useAuth.mockReturnValue({ me: ME_APPROVER });
     useProjectPOs.mockReturnValue({ isLoading: true });
     renderWithProviders(<POApprovalsTab />);
     expect(screen.getByTestId('po-approvals-loading')).toBeInTheDocument();
   });
 
   test('error state renders po-approvals-error', () => {
-    useAuth.mockReturnValue({ user: ME_APPROVER });
+    useAuth.mockReturnValue({ me: ME_APPROVER });
     useProjectPOs.mockReturnValue({ isError: true });
     renderWithProviders(<POApprovalsTab />);
     expect(screen.getByTestId('po-approvals-error')).toBeInTheDocument();

--- a/frontend/src/context/__tests__/AuthContext.shape.test.jsx
+++ b/frontend/src/context/__tests__/AuthContext.shape.test.jsx
@@ -1,0 +1,73 @@
+/**
+ * AuthContext value-shape regression test (Chat 28).
+ *
+ * Mounts the REAL `AuthProvider` from `@/context/AuthContext` and
+ * inspects the value object exposed via `useAuth()`. Asserts:
+ *
+ *   - `me` is the canonical key (matches state: `const [me, setMe] =
+ *     useState(null)` at AuthContext.jsx:38).
+ *   - `user` is NOT a key on the context value.
+ *
+ * This catches the 7-file Chat-24/R5 latent bug (`const { user } =
+ * useAuth()` → undefined → `canViewPOs(undefined)` → forbidden
+ * branch → `<po-list>` never mounts) AND any future file that copies
+ * the bad pattern. One shared assertion replaces per-component
+ * duplication.
+ *
+ * The bug bypassed Jest because component tests mock `useAuth`
+ * directly (jest.mock('../../../context/AuthContext')) — the mock
+ * shape is whatever the test author writes, so the real provider's
+ * value never gets asserted against. This test bridges that gap by
+ * importing the REAL provider.
+ */
+import React from 'react';
+import { render, act, waitFor } from '@testing-library/react';
+
+import { AuthProvider, useAuth } from '@/context/AuthContext';
+
+// Mock the boot-time GET /auth/me so the provider settles without a
+// real network call. We only care about the value-shape; the data
+// payload is irrelevant.
+jest.mock('@/lib/api', () => ({
+  api: {
+    get: jest.fn().mockResolvedValue({ data: null }),
+    post: jest.fn(),
+  },
+}));
+
+function CaptureContext({ onCapture }) {
+  const ctx = useAuth();
+  React.useEffect(() => { onCapture(ctx); }, [ctx, onCapture]);
+  return null;
+}
+
+
+describe('AuthContext provider value shape (regression — Chat 28)', () => {
+  test('exposes `me` (NOT `user`) — any component destructuring `user` will silently break', async () => {
+    let captured = null;
+    await act(async () => {
+      render(
+        <AuthProvider>
+          <CaptureContext onCapture={(ctx) => { captured = ctx; }} />
+        </AuthProvider>,
+      );
+    });
+    await waitFor(() => expect(captured).not.toBeNull());
+
+    const keys = Object.keys(captured);
+    // The bug: a file destructuring `user` from useAuth() gets
+    // undefined and silently falls through every `canXxx(user)`
+    // guard. Asserting `user` is absent prevents the bad pattern
+    // from re-emerging.
+    expect(keys).toContain('me');
+    expect(keys).not.toContain('user');
+
+    // Sanity-check the rest of the documented contract so a future
+    // refactor that renames `me` (without updating every consumer)
+    // also fails loudly here.
+    expect(keys).toEqual(expect.arrayContaining([
+      'state', 'me', 'login', 'submitMfa', 'logout', 'refresh',
+      'hasPerm', 'hasAnyPerm',
+    ]));
+  });
+});

--- a/frontend/src/pages/SupplierDetail.jsx
+++ b/frontend/src/pages/SupplierDetail.jsx
@@ -19,9 +19,9 @@ import SensitiveValue from '@/components/po/SensitiveValue';
 
 export default function SupplierDetail() {
   const { id } = useParams();
-  const { user } = useAuth();
+  const { me } = useAuth();
   const navigate = useNavigate();
-  const canSensitive = canViewSensitiveSupplier(user);
+  const canSensitive = canViewSensitiveSupplier(me);
 
   const { data: s, isLoading, isError } = useSupplier(id);
   const archive = useArchiveSupplier();
@@ -43,14 +43,14 @@ export default function SupplierDetail() {
           <div className="text-xs text-sy-grey-600">{s.status} · CIS {s.cis_status ?? 'None'}</div>
         </div>
         <div className="flex gap-2">
-          {canEditSupplier(user) && (
+          {canEditSupplier(me) && (
             <Link
               to={`/suppliers/${s.id}/edit`}
               className="px-3 py-1.5 rounded border text-sm"
               data-testid="supplier-detail-edit-btn"
             >Edit</Link>
           )}
-          {canArchiveSupplier(user) && s.status !== 'Archived' && (
+          {canArchiveSupplier(me) && s.status !== 'Archived' && (
             <button
               type="button" onClick={onArchive}
               className="px-3 py-1.5 rounded border text-sm text-red-700"

--- a/frontend/src/pages/SupplierForm.jsx
+++ b/frontend/src/pages/SupplierForm.jsx
@@ -38,9 +38,9 @@ export default function SupplierForm() {
   const { id } = useParams();
   const navigate = useNavigate();
   const isEdit = !!id;
-  const { user } = useAuth();
-  const canSensitive = canViewSensitiveSupplier(user);
-  const canSubmit = isEdit ? canEditSupplier(user) : canCreateSupplier(user);
+  const { me } = useAuth();
+  const canSensitive = canViewSensitiveSupplier(me);
+  const canSubmit = isEdit ? canEditSupplier(me) : canCreateSupplier(me);
 
   const { data: existing } = useSupplier(id, { enabled: isEdit });
   const create = useCreateSupplier();

--- a/frontend/src/pages/SupplierList.jsx
+++ b/frontend/src/pages/SupplierList.jsx
@@ -14,7 +14,7 @@ import { useAuth } from '@/context/AuthContext';
 import { canCreateSupplier, canViewSuppliers } from '@/lib/poCapability';
 
 export default function SupplierList() {
-  const { user } = useAuth();
+  const { me } = useAuth();
   const [statusFilter, setStatusFilter] = useState('Active');
   const [search, setSearch] = useState('');
 
@@ -24,7 +24,7 @@ export default function SupplierList() {
 
   const rows = useMemo(() => data?.items ?? [], [data]);
 
-  if (!canViewSuppliers(user)) {
+  if (!canViewSuppliers(me)) {
     return (
       <div className="p-6 text-sm" data-testid="supplier-list-forbidden">
         You do not have permission to view suppliers.
@@ -36,7 +36,7 @@ export default function SupplierList() {
     <div className="p-6 space-y-4" data-testid="supplier-list">
       <header className="flex items-center justify-between">
         <h1 className="text-xl font-semibold">Suppliers</h1>
-        {canCreateSupplier(user) && (
+        {canCreateSupplier(me) && (
           <Link
             to="/suppliers/new"
             className="px-3 py-1.5 rounded bg-sy-teal-600 text-white text-sm"

--- a/frontend/src/pages/projects/NumberPrefixManager.jsx
+++ b/frontend/src/pages/projects/NumberPrefixManager.jsx
@@ -20,9 +20,9 @@ const TABS = ['PO', 'Bill'];
 
 export default function NumberPrefixManager() {
   const { id: projectId } = useParams();
-  const { user } = useAuth();
+  const { me } = useAuth();
   const [tab, setTab] = useState('PO');
-  const canEdit = canEditPrefixes(user);
+  const canEdit = canEditPrefixes(me);
 
   const { data, isLoading, isError } = usePrefixes(projectId, {
     params: { document_type: tab },
@@ -30,7 +30,7 @@ export default function NumberPrefixManager() {
   const createMut = useCreatePrefix(projectId);
   const patchMut = usePatchPrefix(projectId);
 
-  if (!canViewPrefixes(user)) {
+  if (!canViewPrefixes(me)) {
     return <div className="p-6 text-sm" data-testid="prefix-manager-forbidden">
       You do not have permission to view number prefixes.
     </div>;

--- a/frontend/src/pages/projects/PurchaseOrderForm.jsx
+++ b/frontend/src/pages/projects/PurchaseOrderForm.jsx
@@ -25,8 +25,8 @@ function blankLine() {
 export default function PurchaseOrderForm() {
   const { id: projectId } = useParams();
   const navigate = useNavigate();
-  const { user } = useAuth();
-  const canSensitive = canViewSensitivePO(user);
+  const { me } = useAuth();
+  const canSensitive = canViewSensitivePO(me);
 
   const [supplierId, setSupplierId] = useState('');
   const [budgetId, setBudgetId] = useState('');
@@ -40,7 +40,7 @@ export default function PurchaseOrderForm() {
     if (!issueDate) setIssueDate(new Date().toISOString().slice(0, 10));
   }, [issueDate]);
 
-  if (!canCreatePO(user)) {
+  if (!canCreatePO(me)) {
     return <div className="p-6 text-sm" data-testid="po-form-forbidden">
       You do not have permission to create purchase orders.
     </div>;

--- a/frontend/src/pages/projects/PurchaseOrderList.jsx
+++ b/frontend/src/pages/projects/PurchaseOrderList.jsx
@@ -32,19 +32,19 @@ const TABS = ['all', 'approvals'];
 
 export default function PurchaseOrderList() {
   const { id: projectId } = useParams();
-  const { user } = useAuth();
+  const { me } = useAuth();
   const [searchParams, setSearchParams] = useSearchParams();
   const status = searchParams.get('status') || '';
   const tab = searchParams.get('tab') === 'approvals' ? 'approvals' : 'all';
 
-  const canSensitive = canViewSensitivePO(user);
+  const canSensitive = canViewSensitivePO(me);
   const { data, isLoading, isError } = useProjectPOs(projectId, {
     params: status ? { status } : undefined,
     enabled: tab === 'all',
   });
   const rows = data?.items ?? [];
 
-  if (!canViewPOs(user)) {
+  if (!canViewPOs(me)) {
     return <div className="p-6 text-sm" data-testid="po-list-forbidden">
       You do not have permission to view purchase orders.
     </div>;
@@ -66,7 +66,7 @@ export default function PurchaseOrderList() {
     <div className="p-6 space-y-4" data-testid="po-list">
       <header className="flex items-center justify-between">
         <h1 className="text-xl font-semibold">Purchase orders</h1>
-        {canCreatePO(user) && (
+        {canCreatePO(me) && (
           <Link
             to={`/projects/${projectId}/purchase-orders/new`}
             className="px-3 py-1.5 rounded bg-sy-teal-600 text-white text-sm"


### PR DESCRIPTION
fix(auth): rename `user` → `me` in 7 files to match AuthContext shape

Latent Chat-24/R5 bug surfaced by Chat 28 R7.5 E2E. The `useAuth()`
provider exposes `{ me }`; these 7 files destructured `user`, so
`canViewPOs(undefined)` short-circuited and `po-list` never mounted.
Inherited into POApprovalsTab via copy-paste in Batch 2.

Files: PurchaseOrderList, PurchaseOrderForm, NumberPrefixManager,
SupplierList, SupplierForm, SupplierDetail, POApprovalsTab.

Regression: tests/auth-context-shape.test.jsx asserts `me` key
presence on context value.

Fixes: 7 @po-batch2 E2E specs.